### PR TITLE
Pin Node version to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "url": "https://github.com/nytimes/library/issues"
   },
   "engines": {
-    "node": ">=10.x",
-    "npm": ">=6.5.x"
+    "node": "16.x",
   },
   "homepage": "https://github.com/nytimes/library#readme"
 }


### PR DESCRIPTION
The current Node version pinning in package.json means "16 or later", which can cause unintended effects (it's currently running on v18 in production). I'd recommend we pin it to Node 16 specifically (or 18 if we so desire) to avoid it upgrading outside of an expected major version.