### PR TITLE
Include *.google.com as acceptable image source

### DIFF
--- a/server/csp.json
+++ b/server/csp.json
@@ -3,7 +3,7 @@
   "scriptSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "*.google-analytics.com"],
   "styleSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com", "*.googleusercontent.com"],
   "fontSrc": ["'self'", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com"],
-  "imgSrc": ["'self'", "data:", "*.googleusercontent.com", "*.google-analytics.com"],
+  "imgSrc": ["'self'", "data:", "*.googleusercontent.com", "*.google-analytics.com", "*.google.com"],
   "frameSrc": ["'self'","data:","*.youtube.com"],
   "objectSrc": ["'none'"]
 }


### PR DESCRIPTION
Due to Google working in mysterious ways, some of our images hosted on `*.googleusercontent.com` are first redirected via `google.com` and then back to the former domain. This causes our CSP to block the images.

This fix simply includes `*.google.com` domains as acceptable image sources.